### PR TITLE
fix: resolve ESLint anonymous default export warnings for CI/CD

### DIFF
--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -152,4 +152,5 @@ class AccountService {
   }
 }
 
-export default new AccountService();
+const accountService = new AccountService();
+export default accountService;

--- a/src/services/analyticsService.js
+++ b/src/services/analyticsService.js
@@ -8,4 +8,5 @@ class AnalyticsService {
   // Placeholder - will implement in Phase 4
 }
 
-export default new AnalyticsService();
+const analyticsService = new AnalyticsService();
+export default analyticsService;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -211,4 +211,5 @@ class ApiService {
   }
 }
 
-export default new ApiService();
+const apiService = new ApiService();
+export default apiService;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -137,4 +137,5 @@ class AuthService {
   }
 }
 
-export default new AuthService();
+const authService = new AuthService();
+export default authService;

--- a/src/services/budgetService.js
+++ b/src/services/budgetService.js
@@ -8,4 +8,5 @@ class BudgetService {
   // Placeholder - will implement in Phase 4
 }
 
-export default new BudgetService();
+const budgetService = new BudgetService();
+export default budgetService;

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -185,4 +185,5 @@ class CategoryService {
   }
 }
 
-export default new CategoryService();
+const categoryService = new CategoryService();
+export default categoryService;

--- a/src/services/currencyService.js
+++ b/src/services/currencyService.js
@@ -8,4 +8,5 @@ class CurrencyService {
   // Placeholder - will implement in Phase 4
 }
 
-export default new CurrencyService();
+const currencyService = new CurrencyService();
+export default currencyService;

--- a/src/services/goalService.js
+++ b/src/services/goalService.js
@@ -8,4 +8,5 @@ class GoalService {
   // Placeholder - will implement in Phase 4
 }
 
-export default new GoalService();
+const goalService = new GoalService();
+export default goalService;

--- a/src/services/recurringService.js
+++ b/src/services/recurringService.js
@@ -8,4 +8,5 @@ class RecurringService {
   // Placeholder - will implement in Phase 4
 }
 
-export default new RecurringService();
+const recurringService = new RecurringService();
+export default recurringService;

--- a/src/services/tokenManager.js
+++ b/src/services/tokenManager.js
@@ -79,4 +79,5 @@ class TokenManager {
   }
 }
 
-export default new TokenManager();
+const tokenManager = new TokenManager();
+export default tokenManager;

--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -185,4 +185,5 @@ class TransactionService {
   }
 }
 
-export default new TransactionService();
+const transactionService = new TransactionService();
+export default transactionService;


### PR DESCRIPTION
Fixed all service files to avoid anonymous default exports by assigning instances to variables before exporting. This resolves the import/no-anonymous-default-export ESLint rule that was causing Netlify deployment failures.

Changed pattern from:
  export default new ClassName();

To:
  const serviceInstance = new ClassName();
  export default serviceInstance;

Files fixed:
- accountService.js
- transactionService.js
- categoryService.js
- authService.js
- api.js
- tokenManager.js
- analyticsService.js
- budgetService.js
- currencyService.js
- goalService.js
- recurringService.js

This allows the build to pass in CI environments where process.env.CI = true treats warnings as errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)