### PR TITLE
fix: send login credentials as object instead of separate parameters

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -181,7 +181,7 @@ export function AppProvider({ children }) {
    */
   const login = async (email, password) => {
     try {
-      const user = await authService.login(email, password);
+      const user = await authService.login({ email, password });
       setUser(user);
       setIsAuthenticated(true);
       return user;


### PR DESCRIPTION
Changed authService.login(email, password) to authService.login({ email, password })

This was causing only the email to be sent, not the password, resulting in 400 Bad Request errors on login.

Fixes the 'Unexpected token in JSON' error during login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)