### PR TITLE
fix: correct user state extraction in login and register

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -181,10 +181,12 @@ export function AppProvider({ children }) {
    */
   const login = async (email, password) => {
     try {
-      const user = await authService.login({ email, password });
-      setUser(user);
+      const response = await authService.login({ email, password });
+      // authService.login returns { user, token, refreshToken }
+      // We only need to set the user object in state (tokens are already stored by authService)
+      setUser(response.user);
       setIsAuthenticated(true);
-      return user;
+      return response.user;
     } catch (error) {
       throw error;
     }
@@ -196,10 +198,12 @@ export function AppProvider({ children }) {
    */
   const register = async (userData) => {
     try {
-      const user = await authService.register(userData);
-      setUser(user);
+      const response = await authService.register(userData);
+      // authService.register returns { user, token, refreshToken }
+      // We only need to set the user object in state (tokens are already stored by authService)
+      setUser(response.user);
       setIsAuthenticated(true);
-      return user;
+      return response.user;
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
Fix authentication bug causing redirect loop to login page.

Issue:
- After successful login, user was redirected back to login page
- authService.login() returns { user, token, refreshToken }
- AppContext was setting entire object as user state
- This caused user state to be incorrectly structured
- ProtectedRoute checks failed because user object was malformed

Solution:
- Extract response.user before setting state
- Set only the user object, not the entire response
- Tokens are already stored by authService.login()
- Applied same fix to register() method

Before:
  const user = await authService.login({ email, password }); setUser(user); // Sets { user, token, refreshToken }

After:
  const response = await authService.login({ email, password }); setUser(response.user); // Sets only the user object

🤖 Generated with [Claude Code](https://claude.com/claude-code)