### PR TITLE
fix: dark/light theme toggle now works correctly

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -277,8 +277,9 @@ export function AppProvider({ children }) {
   const updateUser = (updates) => {
     const updatedUser = { ...user, ...updates };
     setUser(updatedUser);
-    // Note: This only updates local state
-    // Backend profile update will be added in Settings integration
+    // Persist to localStorage so theme and other preferences are saved
+    tokenManager.setUser(updatedUser);
+    // Note: Backend profile update for other fields will be added in Settings integration
   };
 
   /**


### PR DESCRIPTION
Fixed the theme toggle issue where the theme would not change regardless of user selection.

Changes made:
1. Added theme initialization in currentUser (defaults to 'light' if not present)
2. Updated useEffect to listen to currentUser.theme instead of state.user.theme
3. Created setTheme() helper function to handle theme changes for both authenticated and demo modes
4. For authenticated users: updates globalContext.user and persists to localStorage
5. For demo mode: updates local state.user
6. Updated AppContext.updateUser() to persist theme changes to localStorage via tokenManager
7. Fixed Settings view theme buttons to use setTheme() and currentUser
8. Passed setTheme and currentUser as props to SettingsView component

The theme now:
- Persists across page reloads for authenticated users
- Works in both demo and authenticated modes
- Updates immediately when toggled via header button or Settings page
- Is properly saved to localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)