### PR TITLE
fix: force CSS rebuild for class-based dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 /* Import Inter Font from Google Fonts */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
+/* Force rebuild - class-based dark mode */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
Modify index.css to trigger fresh Tailwind CSS build on Netlify. This ensures dark mode uses class strategy instead of media queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)