### PR TITLE
fix: add missing field mappings in transactionService for currency an…

### DIFF
--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -149,13 +149,17 @@ class TransactionService {
       type: apiTxn.type,
       accountId: apiTxn.account_id,
       toAccountId: apiTxn.to_account_id,
+      transferAccountId: apiTxn.to_account_id, // Alias for frontend compatibility
       categoryId: apiTxn.category_id,
+      subcategoryId: apiTxn.subcategory_id,
       amount: apiTxn.amount,
-      currency: apiTxn.currency,
+      currency: apiTxn.currency || 'EUR',
       description: apiTxn.description,
+      payee: apiTxn.description, // Alias for frontend compatibility
       date: apiTxn.transaction_date,
       reconciled: apiTxn.is_reconciled,
       notes: apiTxn.notes,
+      memo: apiTxn.notes, // Alias for frontend compatibility
       createdAt: apiTxn.created_at,
       updatedAt: apiTxn.updated_at,
       // Joined data from backend
@@ -174,13 +178,15 @@ class TransactionService {
     return {
       type: txn.type,
       account_id: txn.accountId || txn.account_id,
-      to_account_id: txn.toAccountId || txn.to_account_id,
-      category_id: txn.categoryId || txn.category_id,
+      to_account_id: txn.toAccountId || txn.to_account_id || null,
+      category_id: txn.categoryId || txn.category_id || null,
+      subcategory_id: txn.subcategoryId || txn.subcategory_id || null,
       amount: txn.amount,
-      description: txn.description,
+      currency: txn.currency || 'EUR',
+      description: txn.description || null,
       transaction_date: txn.date || txn.transaction_date,
-      is_reconciled: txn.reconciled !== undefined ? txn.reconciled : txn.is_reconciled,
-      notes: txn.notes,
+      is_reconciled: txn.reconciled !== undefined ? txn.reconciled : (txn.is_reconciled || false),
+      notes: txn.notes || null,
     };
   }
 }


### PR DESCRIPTION
…d subcategory

## Issue:
Transaction creation was failing with 'Validation failed' because the service wasn't mapping all required fields to the backend format.

## Fixes:

### _mapTransactionToAPI (sending to backend):
- Added subcategory_id mapping (was missing entirely)
- Added currency mapping with EUR default
- Changed empty string defaults to null for optional fields
- Added explicit null fallbacks for to_account_id, category_id

### _mapTransactionFromAPI (receiving from backend):
- Added subcategoryId field mapping
- Added field aliases for frontend compatibility:
  - transferAccountId (alias for toAccountId)
  - payee (alias for description)
  - memo (alias for notes)
- Added currency with EUR default

## Impact:
Transactions should now save successfully to backend without validation errors. All fields properly mapped between frontend camelCase and backend snake_case.