### PR TITLE
fix: remove icon field from category API payload

### DIFF
--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -243,7 +243,7 @@ class CategoryService {
       name: category.name,
       type: category.type,
       color: color,
-      icon: category.icon || null, // Include icon field
+      // Note: Backend doesn't accept 'icon' field on create/update - it only returns it
       parent_id: category.parentId || category.parent_id || null,
       is_active: isActive,
     };


### PR DESCRIPTION
The backend doesn't accept the 'icon' field in create/update requests. It only returns the icon field in responses. Removing this field should fix the "Validation failed" errors when creating categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)