### PR TITLE
fix: omit null/default values in category API payload

### DIFF
--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -239,14 +239,25 @@ class CategoryService {
     // Ensure is_active is always set (default to true)
     const isActive = category.isActive !== undefined ? category.isActive : (category.is_active !== undefined ? category.is_active : true);
 
-    return {
+    // Build payload - only include fields with actual values
+    const payload = {
       name: category.name,
       type: category.type,
       color: color,
-      // Note: Backend doesn't accept 'icon' field on create/update - it only returns it
-      parent_id: category.parentId || category.parent_id || null,
-      is_active: isActive,
     };
+
+    // Only include parent_id if it has a value (don't send null)
+    const parentId = category.parentId || category.parent_id;
+    if (parentId) {
+      payload.parent_id = parentId;
+    }
+
+    // Only include is_active if explicitly set (don't send default true)
+    if (category.isActive !== undefined || category.is_active !== undefined) {
+      payload.is_active = isActive;
+    }
+
+    return payload;
   }
 
   /**


### PR DESCRIPTION
**Root Cause:**
Backend validation was rejecting category creation with "Validation failed" because we were sending null values and default booleans that backend doesn't accept.

**Issue:**
Previous payload included:
- parent_id: null (should be omitted for root categories)
- is_active: true (should be omitted when using default)

Backend validation rejects these null/default values.

**Solution:**
- Only include parent_id field if it has a non-null value
- Only include is_active field if explicitly set by user
- Build payload conditionally to match backend expectations

**Before:**
{
  "name": "Salary", "type": "income", "color": "#10B981",
  "parent_id": null,     ❌ Backend rejects
  "is_active": true      ❌ Backend rejects
}

**After:**
{
  "name": "Salary", "type": "income", "color": "#10B981" // parent_id omitted ✅ // is_active omitted ✅ }

This allows categories to be created successfully in the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)