### PR TITLE
fix: add safety check for account currency display

### DIFF
--- a/src/FinanceTrackerApp.js
+++ b/src/FinanceTrackerApp.js
@@ -1450,7 +1450,9 @@ function TransactionForm({ transaction, onClose }) {
             >
               <option value="">Select Account</option>
               {state.accounts.map(acc => (
-                <option key={acc.id} value={acc.id}>{acc.name} ({acc.currency})</option>
+                <option key={acc.id} value={acc.id}>
+                  {acc.name}{acc.currency ? ` (${acc.currency})` : ''}
+                </option>
               ))}
             </select>
           </div>


### PR DESCRIPTION
Added conditional check to prevent errors when account.currency is undefined. Displays currency only if it exists: 'Account Name (USD)' or 'Account Name'

This prevents runtime errors when rendering account dropdown.