### PR TITLE
fix: add null check for transaction date to prevent crash

### DIFF
--- a/src/FinanceTrackerApp.js
+++ b/src/FinanceTrackerApp.js
@@ -466,8 +466,8 @@ function DashboardView() {
 
   const previousMonth = getPreviousMonth(selectedMonth);
 
-  const currentMonthTxns = state.transactions.filter(t => t.date.startsWith(selectedMonth));
-  const previousMonthTxns = state.transactions.filter(t => t.date.startsWith(previousMonth));
+  const currentMonthTxns = state.transactions.filter(t => t.date && t.date.startsWith(selectedMonth));
+  const previousMonthTxns = state.transactions.filter(t => t.date && t.date.startsWith(previousMonth));
 
   const monthlyIncome = currentMonthTxns.filter(t => t.type === 'income').reduce((sum, t) => sum + t.amount, 0);
   const previousIncome = previousMonthTxns.filter(t => t.type === 'income').reduce((sum, t) => sum + t.amount, 0);


### PR DESCRIPTION
Error was: 'Cannot read properties of undefined (reading startsWith)' at FinanceTrackerApp.js:469

Some transactions were missing date field, causing crash when filtering by month.

Added safety check: t.date && t.date.startsWith() to skip transactions without dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)