### PR TITLE
fix: use regular categories endpoint instead of tree endpoint

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -89,11 +89,14 @@ export function AppProvider({ children }) {
    */
   const loadCategories = async (filters = {}) => {
     try {
-      const data = await categoryService.getCategoriesTree();
+      console.log('📂 Loading categories from backend...');
+      const data = await categoryService.getCategories(filters); // Use regular endpoint, not tree
+      console.log(`📂 Loaded ${data.length} categories from backend`);
       setCategories(data);
       return data;
     } catch (error) {
       console.error('Failed to load categories:', error);
+      console.error('Error details:', error.response?.data || error.message);
       throw error;
     }
   };


### PR DESCRIPTION
ISSUE: Categories created every login (not persisting)

ROOT CAUSE:
- Creating categories: uses /api/categories ✅
- Loading categories: uses /api/categories/tree ❌
- Tree endpoint doesn't exist or returns empty

RESULT:
- Categories save successfully (100/100)
- Next login: loadCategories() returns 0
- Triggers "new user" flow again
- Creates 100 categories again (15 second delay)

FIX:
Changed loadCategories() to use regular getCategories() instead of getCategoriesTree().

Now both create and load use the same endpoint.

Added logging:
- "📂 Loading categories from backend..."
- "📂 Loaded X categories from backend"

This should fix the persistence issue!

🤖 Generated with [Claude Code](https://claude.com/claude-code)