### PR TITLE
fix: remove authService direct import to prevent circular dependency

### DIFF
--- a/src/components/layout/UserMenu.jsx
+++ b/src/components/layout/UserMenu.jsx
@@ -15,7 +15,6 @@ import {
 import { User as UserIcon, Settings, LogOut, ChevronDown, Sun, Moon, Laptop } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { createPageUrl } from "@/utils";
-import authService from "@/services/authService";
 
 export default function UserMenu({ onThemeChange }) {
   const [currentUser, setCurrentUser] = useState(null);
@@ -41,14 +40,19 @@ export default function UserMenu({ onThemeChange }) {
 
   const handleLogout = async () => {
     try {
-      // Clear tokens and logout
-      await authService.logout();
-      // Navigate to login page using React Router
+      // Logout using the User adapter method
+      await User.logout();
+      // Navigate to login page
       navigate('/login', { replace: true });
     } catch (error) {
       console.error("Error during logout:", error);
-      // Even if error, navigate to login
-      navigate('/login', { replace: true });
+      // Even if error, try to navigate
+      try {
+        navigate('/login', { replace: true });
+      } catch (navError) {
+        // Fallback to window location if navigate fails
+        window.location.href = '/login';
+      }
     }
   };
 


### PR DESCRIPTION
- Removed direct authService import from UserMenu
- Now uses User.logout() method instead
- Added fallback error handling for navigation
- This should fix the runtime crash

If still broken, user needs to hard refresh browser (Ctrl+Shift+R)