### PR TITLE
fix: prevent category reset when user not loaded + disable button unt…

### DIFF
--- a/src/components/settings/DataManagement.jsx
+++ b/src/components/settings/DataManagement.jsx
@@ -49,12 +49,18 @@ export default function DataManagement({ user }) {
       return;
     }
 
+    if (!user || !user.id) {
+      alert('Error: User not loaded. Please refresh the page and try again.');
+      console.error('User is not loaded:', user);
+      return;
+    }
+
     setIsResetting(true);
     setShowSuccessAlert(false);
 
     try {
       console.log('=== CATEGORY RESET START ===');
-      console.log('User ID:', user?.id);
+      console.log('User ID:', user.id);
 
       // 1. Delete all existing categories for the user
       // First get all parent categories
@@ -208,8 +214,12 @@ export default function DataManagement({ user }) {
 
                 <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
                     <DialogTrigger asChild>
-                        <Button variant="outline" className="border-amber-300 bg-white hover:bg-amber-100/50">
-                            Reset Categories to Default
+                        <Button
+                            variant="outline"
+                            className="border-amber-300 bg-white hover:bg-amber-100/50"
+                            disabled={!user || !user.id}
+                        >
+                            {!user ? 'Loading...' : 'Reset Categories to Default'}
                         </Button>
                     </DialogTrigger>
                     <DialogContent>


### PR DESCRIPTION
…il ready

- Add check for user.id before allowing reset
- Disable button and show 'Loading...' until user is loaded
- Alert user if they somehow trigger reset without user loaded
- Fixes TypeError: Cannot read properties of null (reading 'id')