### PR TITLE
fix: remove user_id from category creation payload

### DIFF
--- a/src/components/settings/DataManagement.jsx
+++ b/src/components/settings/DataManagement.jsx
@@ -128,7 +128,7 @@ export default function DataManagement({ user }) {
           const parentCategory = await Category.create({
             name: cat.name,
             type: type,
-            user_id: user.id, // Backend uses UUID user_id
+            // NOTE: Don't send user_id - backend gets it from JWT token automatically
           });
 
           console.log('Parent category response:', parentCategory);
@@ -151,7 +151,7 @@ export default function DataManagement({ user }) {
                 name: subName,
                 type: type,
                 parent_id: parentCategory.id,
-                user_id: user.id, // Backend uses UUID user_id
+                // NOTE: Don't send user_id - backend gets it from JWT token automatically
               });
               categoriesCreated++;
 

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -252,11 +252,8 @@ class CategoryService {
       type: category.type,
     };
 
-    // Include user_id if provided (required for category creation)
-    const userId = category.userId || category.user_id;
-    if (userId) {
-      payload.user_id = userId;
-    }
+    // NOTE: Do NOT include user_id - backend gets it from JWT token automatically
+    // The validation schema does not accept user_id in the request body
 
     // Only include parent_id if it has a value (don't send null)
     const parentId = category.parentId || category.parent_id;
@@ -264,7 +261,7 @@ class CategoryService {
       payload.parent_id = parentId;
     }
 
-    // Note: Backend does NOT accept 'color', 'icon', or 'is_active' fields on create/update
+    // Note: Backend does NOT accept 'color', 'icon', 'user_id', or 'is_active' fields on create/update
     // These are auto-generated or returned by the backend
 
     return payload;


### PR DESCRIPTION
- Backend validation schema does not accept user_id in request body
- Backend gets user_id from JWT token automatically via middleware
- Updated categoryService._mapCategoryToAPI() to not include user_id
- Updated DataManagement to not pass user_id when creating categories
- Fixes 'Validation failed' error during category reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)