### PR TITLE
fix: make subcategories visible by default in category cards

### DIFF
--- a/src/components/categories/CategoryCard.jsx
+++ b/src/components/categories/CategoryCard.jsx
@@ -152,7 +152,7 @@ const CategoryCard = ({
   onDeleteSubcategory,
   getSubcategoryTransactionCount
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const colors = typeColors[category.type] || typeColors.expense;
   const Icon = categoryIcons[category.name] || categoryIcons.Default;
 


### PR DESCRIPTION
Changed the initial state of the collapsible from closed to open, so subcategories are now displayed by default without requiring users to click to expand them. This improves UX by making subcategories immediately visible.

Generated with [Claude Code](https://claude.com/claude-code)