### PR TITLE
debug: add filtering to prevent duplicates and log backend behavior

### DIFF
--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -42,13 +42,26 @@ class CategoryService {
       for (const parent of parents) {
         try {
           const subcategoryUrl = `${API_ENDPOINTS.CATEGORIES}?parent_id=${parent.id}`;
-          console.log(`Fetching subcategories for ${parent.name}:`, subcategoryUrl);
+          console.log(`Fetching subcategories for ${parent.name} (${parent.id}):`, subcategoryUrl);
 
           const subResponse = await api.get(subcategoryUrl);
           const subcategories = subResponse.data.data;
-          console.log(`  Found ${subcategories.length} subcategories for ${parent.name}`);
 
-          allCategories.push(...subcategories);
+          console.log(`  Backend returned ${subcategories.length} items for ${parent.name}`);
+
+          if (subcategories.length > 0) {
+            console.log(`  First item:`, subcategories[0]);
+            console.log(`  First item parent_id:`, subcategories[0].parent_id);
+            console.log(`  Items with parent_id matching ${parent.id}:`,
+              subcategories.filter(c => c.parent_id === parent.id).length
+            );
+          }
+
+          // Only add items that actually have this parent_id
+          const actualSubcategories = subcategories.filter(c => c.parent_id === parent.id);
+          console.log(`  Adding ${actualSubcategories.length} actual subcategories`);
+
+          allCategories.push(...actualSubcategories);
         } catch (error) {
           console.warn(`Failed to fetch subcategories for ${parent.name}:`, error);
           // Continue with other parents even if one fails


### PR DESCRIPTION
Added detailed logging to see what backend returns for parent_id queries. Also added client-side filtering to only include items that actually have the matching parent_id, in case backend ignores the filter.

This should prevent the 182 duplicate categories issue (13 parents + 13 parents returned 13 times = 182).

🤖 Generated with [Claude Code](https://claude.com/claude-code)