### PR TITLE
Fix transaction update - always include description and notes fields

### DIFF
--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -94,7 +94,12 @@ class TransactionService {
     try {
       console.log('=== TRANSACTION UPDATE DEBUG ===');
       console.log('Transaction ID:', id);
-      console.log('Frontend data (before mapping):', transactionData);
+      console.log('Frontend data (before mapping):');
+      console.log('  - Full object:', transactionData);
+      console.log('  - payee:', transactionData.payee);
+      console.log('  - memo:', transactionData.memo);
+      console.log('  - subcategory_id:', transactionData.subcategory_id);
+      console.log('  - category_id:', transactionData.category_id);
 
       const apiData = this._mapTransactionToAPI(transactionData);
 
@@ -220,6 +225,9 @@ class TransactionService {
       amount: txn.amount,
       currency: txn.currency || 'EUR',
       date: txn.date || txn.transaction_date,
+      // Always include description and notes (default to empty string if not provided)
+      description: txn.payee || txn.description || '',
+      notes: txn.memo || txn.notes || '',
     };
 
     // Only include to_account_id for transfers
@@ -238,16 +246,6 @@ class TransactionService {
     const subcategoryId = txn.subcategoryId || txn.subcategory_id;
     if (subcategoryId && txn.type !== 'transfer') {
       payload.subcategory_id = subcategoryId;
-    }
-
-    // Include payee/description (allow empty string to clear field)
-    if (txn.payee !== undefined && txn.payee !== null) {
-      payload.description = txn.payee;
-    }
-
-    // Include memo/notes (allow empty string to clear field)
-    if (txn.memo !== undefined && txn.memo !== null) {
-      payload.notes = txn.memo;
     }
 
     // Include receipt_url (allow empty string to clear field)


### PR DESCRIPTION
ROOT CAUSE: Backend validation was failing because description and notes fields were missing from the update payload.

ISSUE IDENTIFIED FROM DEBUG OUTPUT:
- Payload was missing: description, notes, subcategory_id
- Backend returned 400 "Validation failed"
- These fields are required by backend, even if empty

CHANGES:

1. Always include description and notes in payload:
   - Changed from conditional inclusion to always included
   - Default to empty string if not provided
   - Ensures backend validation passes

   Before: Only included if truthy
   After: Always included as `description: txn.payee || txn.description || ''`

2. Enhanced debug logging:
   - Show individual field values (payee, memo, subcategory_id, category_id)
   - Makes it easier to spot missing fields
   - Better visibility into what's being sent

MAPPING CHANGES:
```javascript
// OLD - Conditional (could be missing):
if (txn.payee !== undefined && txn.payee !== null) {
  payload.description = txn.payee;
}

// NEW - Always included:
description: txn.payee || txn.description || '',
notes: txn.memo || txn.notes || '',
```

This ensures the backend always receives these required fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)