### PR TITLE
Fix transaction update not working - ensure fields are never undefined

### DIFF
--- a/src/components/transactions/TransactionForm.jsx
+++ b/src/components/transactions/TransactionForm.jsx
@@ -52,6 +52,9 @@ export default function TransactionForm({
         ...transaction,
         date: format(new Date(transaction.date || new Date()), 'yyyy-MM-dd'),
         amount: transaction.amount ? transaction.amount.toString() : '', // Ensure amount is string for input
+        payee: transaction.payee || '', // Ensure payee is never undefined
+        memo: transaction.memo || '', // Ensure memo is never undefined
+        subcategory_id: transaction.subcategory_id || '', // Ensure subcategory_id is never undefined
         receipt_url: transaction.receipt_url || '' // Load existing receipt url
       });
     }


### PR DESCRIPTION
ROOT CAUSE: When editing an existing transaction that was created without payee/memo/subcategory fields, these fields had undefined values. When the form loaded this transaction with `...transaction`, the undefined values overrode the default empty strings in the initial form state.

This caused:
- payee: undefined (instead of "")
- memo: undefined (instead of "")
- subcategory_id: undefined (instead of "")

When submitted, the service mapped undefined to empty strings, but the frontend data already had undefined, causing backend validation to fail.

FIX:
In TransactionForm.jsx useEffect that loads transaction data:
- Explicitly set payee: transaction.payee || ''
- Explicitly set memo: transaction.memo || ''
- Explicitly set subcategory_id: transaction.subcategory_id || ''

This ensures these fields are ALWAYS strings (empty string if undefined), preventing undefined from being passed through the update flow.

RESULT: Transaction updates will now work correctly, even when editing transactions that were created without these optional fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)