### PR TITLE
Fix transaction update - remove currency field from payload

### DIFF
--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -218,11 +218,10 @@ class TransactionService {
    * @private
    */
   _mapTransactionToAPI(txn) {
-    // Build payload - only include fields that exist in the database
+    // Build payload - only include fields that can be updated in the database
     const payload = {
       date: txn.date || txn.transaction_date,
       amount: txn.amount,
-      currency: txn.currency || 'EUR',
       // Map frontend field names to database column names
       payee: txn.payee || txn.description || '',
       memo: txn.memo || txn.notes || '',


### PR DESCRIPTION
- Currency is tied to account and cannot be changed on update
- Backend validator doesn't accept currency field for updates
- Only send: date, amount, payee, memo, category_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)