### PR TITLE
Fix rate limiting - remove redundant category API calls from all pages

### DIFF
--- a/src/pages/Insights.jsx
+++ b/src/pages/Insights.jsx
@@ -1,9 +1,10 @@
 
 import React, { useState, useEffect, useCallback } from "react";
-import { User, Transaction, Category, Account, SpendingAlert, CategorizationRule } from "@/api/entities";
+import { User, Transaction, Account, SpendingAlert, CategorizationRule } from "@/api/entities";
 import { InvokeLLM } from "@/api/integrations";
 import { Zap, TrendingUp, AlertTriangle, Brain, Lightbulb, Target, Calendar } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useApp } from "../context/AppContext";
 
 import SpendingInsights from "../components/insights/SpendingInsights";
 import SmartAlerts from "../components/insights/SmartAlerts";
@@ -12,13 +13,16 @@ import AutoCategorizationRules from "../components/insights/AutoCategorizationRu
 import PeriodComparison from "../components/insights/PeriodComparison";
 
 export default function InsightsPage() {
+  const { categories: sharedCategories } = useApp();
   const [currentUser, setCurrentUser] = useState(null);
   const [transactions, setTransactions] = useState([]);
-  const [categories, setCategories] = useState([]);
   const [accounts, setAccounts] = useState([]);
   const [spendingAlerts, setSpendingAlerts] = useState([]);
   const [categorizationRules, setCategorizationRules] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // Use shared categories from AppContext
+  const categories = sharedCategories;
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -26,16 +30,14 @@ export default function InsightsPage() {
       const user = await User.me();
       setCurrentUser(user);
 
-      const [transactionsData, categoriesData, accountsData, alertsData, rulesData] = await Promise.all([
+      const [transactionsData, accountsData, alertsData, rulesData] = await Promise.all([
         Transaction.filter({}, '-date'),
-        Category.filter({ is_active: true }),
         Account.filter({ is_active: true }),
         SpendingAlert.filter({}),
         CategorizationRule.filter({})
       ]);
 
       setTransactions(transactionsData);
-      setCategories(categoriesData);
       setAccounts(accountsData);
       setSpendingAlerts(alertsData);
       setCategorizationRules(rulesData);

--- a/src/pages/Recurring.jsx
+++ b/src/pages/Recurring.jsx
@@ -1,16 +1,17 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { User, RecurrentTransaction, TransactionTemplate, Account, Category } from "@/api/entities";
+import { User, RecurrentTransaction, TransactionTemplate, Account } from "@/api/entities";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Plus, Repeat, FileText } from "lucide-react";
 import RecurrentTransactionList from "../components/recurring/RecurrentTransactionList";
 import TransactionTemplateList from "../components/recurring/TransactionTemplateList";
+import { useApp } from "../context/AppContext";
 
 export default function RecurringPage() {
+    const { categories } = useApp();
     const [recurrentTransactions, setRecurrentTransactions] = useState([]);
     const [transactionTemplates, setTransactionTemplates] = useState([]);
     const [accounts, setAccounts] = useState([]);
-    const [categories, setCategories] = useState([]);
     const [currentUser, setCurrentUser] = useState(null);
     const [isLoading, setIsLoading] = useState(true);
 
@@ -20,17 +21,15 @@ export default function RecurringPage() {
             const user = await User.me();
             setCurrentUser(user);
 
-            const [recTrans, tempTrans, accData, catData] = await Promise.all([
+            const [recTrans, tempTrans, accData] = await Promise.all([
                 RecurrentTransaction.filter({}),
                 TransactionTemplate.filter({}),
-                Account.filter({}),
-                Category.filter({})
+                Account.filter({})
             ]);
 
             setRecurrentTransactions(recTrans);
             setTransactionTemplates(tempTrans);
             setAccounts(accData);
-            setCategories(catData);
         } catch (error) {
             console.error("Error loading recurring data:", error);
         }

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -1,18 +1,19 @@
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { User, Account, Category, Transaction } from '@/api/entities';
+import { User, Account, Transaction } from '@/api/entities';
 import { FilePieChart } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ReportFilters from '../components/reports/ReportFilters';
 import ReportDisplay from '../components/reports/ReportDisplay';
 import CustomReportBuilder from '../components/reports/CustomReportBuilder';
+import { useApp } from '../context/AppContext';
 
 import { startOfMonth, endOfMonth } from 'date-fns';
 
 export default function ReportsPage() {
+  const { categories } = useApp();
   const [currentUser, setCurrentUser] = useState(null);
   const [accounts, setAccounts] = useState([]);
-  const [categories, setCategories] = useState([]);
   const [transactions, setTransactions] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -28,13 +29,11 @@ export default function ReportsPage() {
   const loadData = useCallback(async (user) => {
     setIsLoading(true);
     try {
-      const [accountsData, categoriesData, transactionsData] = await Promise.all([
+      const [accountsData, transactionsData] = await Promise.all([
         Account.filter({}),
-        Category.filter({}),
         Transaction.filter({}, '-date'),
       ]);
       setAccounts(accountsData);
-      setCategories(categoriesData);
       setTransactions(transactionsData);
     } catch (error) {
       console.error("Error loading report data:", error);


### PR DESCRIPTION
- Updated Budget.jsx to use shared categories from AppContext
- Updated Categories.jsx to sync with AppContext's loadCategories
- Updated Insights.jsx to use shared categories
- Updated Recurring.jsx to use shared categories
- Updated Reports.jsx to use shared categories
- Removed Category.filter() calls from 5 pages
- Categories now loaded once on login/auth instead of per page
- Fixes "Too many requests" rate limiting error

🤖 Generated with [Claude Code](https://claude.com/claude-code)