### PR TITLE
Fix transaction updates - save subcategory as category_id

### DIFF
--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -239,7 +239,8 @@ class TransactionService {
     }
 
     // Add category_id for income/expense (optional)
-    const categoryId = txn.categoryId || txn.category_id;
+    // If subcategory is selected, use it as category_id (subcategories are just categories with parent_id)
+    const categoryId = txn.subcategory_id || txn.categoryId || txn.category_id;
     if (categoryId && txn.type !== 'transfer') {
       payload.category_id = categoryId;
     }
@@ -259,8 +260,9 @@ class TransactionService {
       memo: txn.memo || txn.notes || '',
     };
 
-    // Only include category_id for income/expense (not for transfers)
-    const categoryId = txn.categoryId || txn.category_id;
+    // If subcategory is selected, use it as category_id (subcategories are just categories with parent_id)
+    // Otherwise use the parent category_id
+    const categoryId = txn.subcategory_id || txn.categoryId || txn.category_id;
     if (categoryId && txn.type !== 'transfer') {
       payload.category_id = categoryId;
     }


### PR DESCRIPTION
- Subcategories are just categories with a parent_id in the database
- When subcategory is selected, use subcategory_id as the category_id
- Updated both CREATE and UPDATE mapping to prioritize subcategory_id
- Fixes issue where selecting subcategory didn't update the transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)