### PR TITLE
Fix transaction display - show parent category and subcategory correctly

### DIFF
--- a/src/components/transactions/TransactionList.jsx
+++ b/src/components/transactions/TransactionList.jsx
@@ -53,12 +53,29 @@ export default function TransactionList({
 
   const getCategoryName = (categoryId) => {
     const category = categories.find(c => c.id === categoryId);
-    return category ? category.name : 'Uncategorized';
+    if (!category) return 'Uncategorized';
+
+    // If this is a subcategory (has parent_id), return the parent's name
+    if (category.parent_id) {
+      const parentCategory = categories.find(c => c.id === category.parent_id);
+      return parentCategory ? parentCategory.name : category.name;
+    }
+
+    // Otherwise return the category's own name
+    return category.name;
   };
 
-  const getSubcategoryName = (subcategoryId) => {
-    const category = categories.find(c => c.id === subcategoryId); // Assuming subcategories are also listed in the categories array
-    return category ? category.name : '';
+  const getSubcategoryName = (categoryId) => {
+    const category = categories.find(c => c.id === categoryId);
+    if (!category) return '';
+
+    // If this is a subcategory (has parent_id), return its name
+    if (category.parent_id) {
+      return category.name;
+    }
+
+    // If it's a parent category, return empty
+    return '';
   };
 
   if (isLoading) {
@@ -165,7 +182,7 @@ export default function TransactionList({
                       <p className="text-sm font-medium text-slate-900">{getCategoryName(transaction.category_id)}</p>
                     </TableCell>
                     <TableCell>
-                      <p className="text-xs text-slate-500">{getSubcategoryName(transaction.subcategory_id) || '-'}</p>
+                      <p className="text-xs text-slate-500">{getSubcategoryName(transaction.category_id) || '-'}</p>
                     </TableCell>
                     <TableCell>
                       <div className="text-right">

--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -260,6 +260,9 @@ class TransactionService {
       memo: txn.memo || txn.notes || '',
     };
 
+    // Note: type, account_id, currency cannot be updated after creation
+    // These fields are immutable once a transaction is created
+
     // If subcategory is selected, use it as category_id (subcategories are just categories with parent_id)
     // Otherwise use the parent category_id
     const categoryId = txn.subcategory_id || txn.categoryId || txn.category_id;


### PR DESCRIPTION
- Updated getCategoryName to show parent category name when category is a subcategory
- Updated getSubcategoryName to show subcategory name when category has parent_id
- Fixed subcategory column to use category_id instead of non-existent subcategory_id field
- Now correctly displays: Category column = parent, Subcategory column = child

Example: Transaction with category_id pointing to "Groceries" (child of "Food & Dining")
- Before: Category="Groceries", Subcategory=(empty)
- After: Category="Food & Dining", Subcategory="Groceries"

Note: Transaction type cannot be changed after creation (by design). To change type, delete and recreate the transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)