### PR TITLE
Fix dark mode persistence issue

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
-import { User } from "@/api/entities";
 import { 
   LayoutDashboard, 
   CreditCard, 
@@ -108,25 +107,17 @@ const navigationItems = [
 
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();
-  const [theme, setTheme] = useState('system');
+  const [theme, setTheme] = useState(() => {
+    // Initialize from localStorage first, fallback to system
+    const savedTheme = localStorage.getItem('app-theme');
+    return savedTheme || 'system';
+  });
 
   const handleThemeChange = (newTheme) => {
     setTheme(newTheme);
+    // Save to localStorage for immediate persistence
+    localStorage.setItem('app-theme', newTheme);
   };
-
-  useEffect(() => {
-    const loadUserTheme = async () => {
-      try {
-        const user = await User.me();
-        if (user && user.theme) {
-          setTheme(user.theme);
-        }
-      } catch (error) {
-        console.warn("Could not load user theme, using system default.");
-      }
-    };
-    loadUserTheme();
-  }, []);
 
   useEffect(() => {
     const root = window.document.documentElement;


### PR DESCRIPTION
Problem:
- Dark mode appeared briefly then reverted immediately
- Two conflicting useEffects were loading user theme from backend
- Backend data was overriding the theme selection

Solution:
1. Removed duplicate theme loading logic from Layout.jsx
2. Use localStorage as single source of truth for theme
3. Layout initializes theme from localStorage on load
4. UserMenu immediately saves theme changes to localStorage
5. Backend sync happens in background (non-blocking)
6. UserMenu only syncs from backend if localStorage is empty

Changes:
- Layout.jsx: Removed User.me() theme fetch, use localStorage
- UserMenu.jsx: Save to localStorage first, backend second
- UserMenu.jsx: Only load from backend if localStorage empty
- Removed unused User import from Layout.jsx

Result: Dark mode now persists correctly without flickering.