### PR TITLE
Fix infinite loop causing rate limit errors on categories page

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -3,7 +3,7 @@
  * Global application state management for authentication and data
  */
 
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useState, useEffect, useCallback } from 'react';
 import authService from '../services/authService';
 import accountService from '../services/accountService';
 import transactionService from '../services/transactionService';
@@ -66,7 +66,7 @@ export function AppProvider({ children }) {
   /**
    * Load accounts from API
    */
-  const loadAccounts = async (filters = {}) => {
+  const loadAccounts = useCallback(async (filters = {}) => {
     try {
       const data = await accountService.getAccounts(filters);
       setAccounts(data);
@@ -75,12 +75,12 @@ export function AppProvider({ children }) {
       console.error('Failed to load accounts:', error);
       throw error;
     }
-  };
+  }, []);
 
   /**
    * Load transactions from API
    */
-  const loadTransactions = async (filters = {}, page = 1, limit = 50) => {
+  const loadTransactions = useCallback(async (filters = {}, page = 1, limit = 50) => {
     try {
       const data = await transactionService.getTransactions(filters, page, limit);
       setTransactions(data.transactions);
@@ -89,12 +89,12 @@ export function AppProvider({ children }) {
       console.error('Failed to load transactions:', error);
       throw error;
     }
-  };
+  }, []);
 
   /**
    * Load categories from API
    */
-  const loadCategories = async (filters = {}) => {
+  const loadCategories = useCallback(async (filters = {}) => {
     try {
       console.log('📂 Loading categories from backend...');
       const data = await categoryService.getCategories(filters); // Use regular endpoint, not tree
@@ -106,7 +106,7 @@ export function AppProvider({ children }) {
       console.error('Error details:', error.response?.data || error.message);
       throw error;
     }
-  };
+  }, []); // No dependencies - function is stable
 
   /**
    * Create multiple categories in bulk (for new users)


### PR DESCRIPTION
Problem:
- Users getting "too many requests" error when accessing categories
- Categories page making infinite API calls to backend
- setupDefaultCategories running multiple times simultaneously

Root Causes:
1. Infinite useEffect loop in Categories.jsx:
   - loadData had loadCategories in dependency array
   - loadCategories was not memoized in AppContext
   - Every AppContext re-render created new loadCategories reference
   - Triggered loadData recreation → useEffect → infinite loop

2. Multiple simultaneous category setups:
   - No guard to prevent setupDefaultCategories from running twice
   - If triggered multiple times, creates 40+ categories repeatedly
   - Easily exceeds backend rate limits

Solution:
1. AppContext.jsx - Memoize all data loading functions:
   - Wrapped loadAccounts with useCallback
   - Wrapped loadTransactions with useCallback
   - Wrapped loadCategories with useCallback
   - Prevents function reference changes on every render

2. Categories.jsx - Add guards against infinite loops:
   - Added isSettingUpRef to prevent multiple setup attempts
   - Added hasLoadedOnce ref to prevent multiple data loads
   - Changed useEffect dependency from [loadData] to []
   - Only run loadData once on component mount
   - setupDefaultCategories checks isSettingUpRef before running

Changes:
- src/context/AppContext.jsx:
  * Import useCallback
  * Wrap loadAccounts, loadTransactions, loadCategories with useCallback

- src/pages/Categories.jsx:
  * Import useRef
  * Add isSettingUpRef and hasLoadedOnce refs
  * Guard setupDefaultCategories with isSettingUpRef check
  * Guard loadData with hasLoadedOnce check
  * Change useEffect to only run once on mount
  * Add console logs for debugging

Result:
- No more infinite API calls
- setupDefaultCategories runs exactly once
- loadData runs exactly once on mount
- No more rate limit errors
- Categories page loads correctly