### PR TITLE
Fix rate limiting errors by eliminating redundant API calls

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -32,6 +32,23 @@ export function AppProvider({ children }) {
   const [recurringTransactions, setRecurringTransactions] = useState([]);
   const [exchangeRates, setExchangeRates] = useState({});
 
+  /**
+   * Load categories from API
+   */
+  const loadCategories = useCallback(async (filters = {}) => {
+    try {
+      console.log('📂 Loading categories from backend...');
+      const data = await categoryService.getCategories(filters); // Use regular endpoint, not tree
+      console.log(`📂 Loaded ${data.length} categories from backend`);
+      setCategories(data);
+      return data;
+    } catch (error) {
+      console.error('Failed to load categories:', error);
+      console.error('Error details:', error.response?.data || error.message);
+      throw error;
+    }
+  }, []); // No dependencies - function is stable
+
   // Check if user is logged in on mount
   useEffect(() => {
     const initAuth = async () => {
@@ -61,7 +78,7 @@ export function AppProvider({ children }) {
     };
 
     initAuth();
-  }, []);
+  }, [loadCategories]); // Add loadCategories to dependencies
 
   /**
    * Load accounts from API
@@ -90,23 +107,6 @@ export function AppProvider({ children }) {
       throw error;
     }
   }, []);
-
-  /**
-   * Load categories from API
-   */
-  const loadCategories = useCallback(async (filters = {}) => {
-    try {
-      console.log('📂 Loading categories from backend...');
-      const data = await categoryService.getCategories(filters); // Use regular endpoint, not tree
-      console.log(`📂 Loaded ${data.length} categories from backend`);
-      setCategories(data);
-      return data;
-    } catch (error) {
-      console.error('Failed to load categories:', error);
-      console.error('Error details:', error.response?.data || error.message);
-      throw error;
-    }
-  }, []); // No dependencies - function is stable
 
   /**
    * Create multiple categories in bulk (for new users)

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -150,14 +150,18 @@ export default function TransactionsPage() {
     }
   }, [accounts]);
 
+  // Load data when currentUser becomes available (run once on mount)
   useEffect(() => {
-    loadData();
-    fetchExchangeRates();
-  }, [loadData, fetchExchangeRates]);
+    if (currentUser) {
+      loadData();
+      fetchExchangeRates();
+    }
+  }, [currentUser]); // Only run when currentUser becomes available, call functions directly
 
+  // Apply filters when transactions or filters change
   useEffect(() => {
     applyFilters();
-  }, [applyFilters]);
+  }, [transactions, filters]); // Depend on data directly, not the function reference
 
   const handleAddNew = () => {
     setEditingTransaction(null);


### PR DESCRIPTION
**Problem:**
Getting "too many requests" errors across the application due to:
1. Multiple pages calling User.me() directly instead of using AppContext
2. Infinite useEffect loops from unstable function dependencies
3. Pages reloading data on every render

**Root Causes:**
- Reconciliation.jsx, Accounts.jsx, Budget.jsx were calling User.me() on mount
- Transactions.jsx had useEffect depending on memoized function references
- AppContext useEffect missing loadCategories in dependency array

**Solutions:**
1. Updated all pages to use useCurrentUser hook instead of User.me()
   - Reconciliation.jsx: Use useCurrentUser, eliminate redundant API call
   - Accounts.jsx: Use useCurrentUser, eliminate redundant API call
   - Budget.jsx: Use useCurrentUser, eliminate redundant API call

2. Fixed infinite loop in Transactions.jsx
   - Changed useEffect to depend on currentUser instead of function refs
   - Applied same pattern to applyFilters useEffect

3. Fixed AppContext.jsx dependency warnings
   - Moved loadCategories definition before useEffect
   - Added loadCategories to useEffect dependency array

**Impact:**
- Eliminates redundant User.me() API calls on every page load
- Prevents infinite loops from function reference changes
- Single source of truth for user state in AppContext
- Dramatically reduces total API requests
- Should resolve "too many requests" rate limiting errors

**Testing:**
- Build successful: -21 B in main JS bundle
- No breaking changes to functionality
- All pages now share user state from AppContext