### PR TITLE
Fix account editing issues: opening balance display and balance updates

### DIFF
--- a/src/components/accounts/AccountForm.jsx
+++ b/src/components/accounts/AccountForm.jsx
@@ -32,8 +32,8 @@ export default function AccountForm({ account, onSubmit, onCancel }) {
         name: account.name || "",
         type: account.type || "checking",
         currency: account.currency || "EUR",
-        opening_balance: account.opening_balance || "",
-        current_balance: account.balance || "",
+        opening_balance: account.openingBalance || account.opening_balance || "",
+        current_balance: account.currentBalance || account.balance || "",
         institution: account.institution || "",
         notes: account.notes || "",
       });

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -181,6 +181,15 @@ class AccountService {
       apiData.interest_rate = account.interest_rate;
     }
 
+    // Allow manual balance adjustments (for reconciliation)
+    if (account.balance !== undefined) {
+      apiData.balance = account.balance;
+    }
+
+    if (account.balance_eur !== undefined) {
+      apiData.balance_eur = account.balance_eur;
+    }
+
     return apiData;
   }
 }


### PR DESCRIPTION
Fixed two critical issues with account editing:

1. Opening balance showing 0.00 instead of actual value
   - AccountForm was looking for snake_case field names (opening_balance)
   - accountService returns camelCase field names (openingBalance)
   - Updated AccountForm to check both formats for compatibility

2. Error when updating current balance
   - accountService._mapAccountToAPI() was stripping balance/balance_eur fields
   - Manual balance adjustments (for reconciliation) were being blocked
   - Added balance and balance_eur to the API mapping when provided

These changes enable proper account editing and manual balance reconciliation.