### PR TITLE
Fix transfer account display and duplicate month in picker

### DIFF
--- a/src/components/transactions/TransactionList.jsx
+++ b/src/components/transactions/TransactionList.jsx
@@ -157,7 +157,12 @@ export default function TransactionList({
                     </TableCell>
                     <TableCell>
                       <div>
-                        <p className="font-medium text-slate-900">{getAccountName(transaction.account_id)}</p>
+                        <p className="font-medium text-slate-900">
+                          {transaction.type === 'transfer'
+                            ? getAccountName(transaction.from_account_id)
+                            : getAccountName(transaction.account_id)
+                          }
+                        </p>
                         {transaction.type === 'transfer' && transaction.to_account_id && (
                           <p className="text-xs text-slate-500">
                             → {getAccountName(transaction.to_account_id)}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -530,6 +530,7 @@ export default function Dashboard() {
             <SelectContent>
               {Array.from({ length: 12 }, (_, i) => {
                 const date = new Date();
+                date.setDate(1); // Set to first day to avoid month overflow issues
                 date.setMonth(date.getMonth() - i);
                 const value = format(date, 'yyyy-MM');
                 return (


### PR DESCRIPTION
Fixed two UI bugs:

1. Transfer transactions showing "Unknown Account"
   - Problem: TransactionList used transaction.account_id for all types
   - Backend stores transfers with from_account_id, not account_id
   - Fix: Check if type is 'transfer' and use from_account_id instead
   - Now correctly shows: "DB Checking → DB Loan" instead of "Unknown Account → DB Loan"

2. Month picker showing October 2025 twice, missing September
   - Problem: Creating dates on Oct 31 and calling setMonth(Sept)
   - JavaScript tries "September 31" which doesn't exist → rolls to Oct 1
   - Classic date overflow bug when subtracting months
   - Fix: Set date.setDate(1) BEFORE calling setMonth()
   - Now correctly shows all 12 unique months