### PR TITLE
Fix transfer transactions to use from_account_id field

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -111,7 +111,11 @@ export default function TransactionsPage() {
     }
 
     if (filters.account !== "all") {
-        filtered = filtered.filter(t => t.account_id === filters.account || t.to_account_id === filters.account);
+        filtered = filtered.filter(t =>
+          t.account_id === filters.account ||
+          t.from_account_id === filters.account ||
+          t.to_account_id === filters.account
+        );
     }
 
     if (filters.type !== "all") {
@@ -169,7 +173,12 @@ export default function TransactionsPage() {
   };
 
   const handleEdit = (transaction) => {
-    setEditingTransaction(transaction);
+    // For transfers, convert from_account_id back to account_id for the form
+    const transactionForForm = { ...transaction };
+    if (transaction.type === 'transfer' && transaction.from_account_id) {
+      transactionForForm.account_id = transaction.from_account_id;
+    }
+    setEditingTransaction(transactionForForm);
     setIsFormOpen(true);
   };
 
@@ -300,6 +309,12 @@ export default function TransactionsPage() {
         exchange_rate: rate,
         user_id: currentUser.id,
       };
+
+      // For transfers, backend expects from_account_id instead of account_id
+      if (formData.type === 'transfer') {
+        dataToSave.from_account_id = formData.account_id;
+        delete dataToSave.account_id;
+      }
 
       console.log('Data to save:', dataToSave);
       console.log('Is update?', !!editingTransaction);


### PR DESCRIPTION
Fixed "Unknown Account" issue when creating/editing transfer transactions.

Problem:
- Form uses account_id for source account
- Backend expects from_account_id for transfers (not account_id)
- This mismatch caused transfers to have null/undefined account_id
- Result: "Unknown Account" displayed in transaction list

Solution:
1. handleSave: Map account_id → from_account_id when type is 'transfer'
2. handleEdit: Convert from_account_id → account_id when loading transfer for editing
3. applyFilters: Check from_account_id in addition to account_id when filtering

Now transfers correctly show:
"DB Checking → DB Loan" instead of "Unknown Account → DB Loan"