### PR TITLE
Add from_account_id mapping for transfer transactions

### DIFF
--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -179,6 +179,8 @@ class TransactionService {
       type: apiTxn.type,
       accountId: apiTxn.account_id,
       account_id: apiTxn.account_id, // Keep both formats for compatibility
+      fromAccountId: apiTxn.from_account_id, // Add from_account_id for transfers
+      from_account_id: apiTxn.from_account_id, // Keep both formats for compatibility
       toAccountId: apiTxn.to_account_id,
       to_account_id: apiTxn.to_account_id, // Keep both formats for compatibility
       transferAccountId: apiTxn.to_account_id, // Alias for frontend compatibility


### PR DESCRIPTION
Fixed the root cause of "Unknown Account" in transfer transactions.

Problem:
- Backend returns transfers with from_account_id field
- transactionService._mapTransactionFromAPI() was NOT mapping from_account_id
- So transaction.from_account_id was undefined in the UI
- TransactionList tried to display getAccountName(transaction.from_account_id)
- Result: "Unknown Account" because from_account_id was undefined

Solution:
- Added from_account_id and fromAccountId to _mapTransactionFromAPI()
- Now properly maps: apiTxn.from_account_id → transaction.from_account_id
- Keeps both camelCase and snake_case for compatibility

This completes the transfer transaction fix. Combined with previous commits:
1. Frontend sends: account_id → backend expects: from_account_id ✓
2. Backend returns: from_account_id → frontend maps: from_account_id ✓ (this fix)
3. UI displays: transaction.from_account_id ✓