### PR TITLE
Fix BDT currency conversion by including amount_eur in transaction pa…

### DIFF
--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -229,6 +229,14 @@ class TransactionService {
       memo: txn.memo || txn.notes || '',
     };
 
+    // Add exchange rate and converted EUR amount if provided
+    if (txn.amount_eur !== undefined) {
+      payload.amount_eur = txn.amount_eur;
+    }
+    if (txn.exchange_rate !== undefined) {
+      payload.exchange_rate = txn.exchange_rate;
+    }
+
     // Add account_id for income/expense
     if (txn.type !== 'transfer') {
       payload.account_id = txn.account_id || txn.accountId;
@@ -261,6 +269,15 @@ class TransactionService {
       payee: txn.payee || txn.description || '',
       memo: txn.memo || txn.notes || '',
     };
+
+    // Add exchange rate and converted EUR amount if provided
+    // (Needed when amount is updated to recalculate EUR equivalent)
+    if (txn.amount_eur !== undefined) {
+      payload.amount_eur = txn.amount_eur;
+    }
+    if (txn.exchange_rate !== undefined) {
+      payload.exchange_rate = txn.exchange_rate;
+    }
 
     // Note: type, account_id, currency cannot be updated after creation
     // These fields are immutable once a transaction is created


### PR DESCRIPTION
…yload

Root cause: Frontend was calculating amount_eur and exchange_rate correctly (e.g., 1000 BDT = 8.4 EUR), but transactionService._mapTransactionForCreate() was stripping these fields from the payload before sending to backend. This caused backend to use default rate of 1, showing 1000 BDT as 1000 EUR.

Changes:
- Add amount_eur and exchange_rate to _mapTransactionForCreate() payload
- Add amount_eur and exchange_rate to _mapTransactionForUpdate() payload
- Both fields are conditionally included if provided by frontend

This ensures currency conversion works correctly for all non-EUR transactions (BDT, USD, etc).