### PR TITLE
Fix budget creation validation error - use correct field name 'budgeted'

### DIFF
--- a/src/pages/Budget.jsx
+++ b/src/pages/Budget.jsx
@@ -85,8 +85,7 @@ export default function BudgetPage() {
         await Budget.create({
           month: monthString,
           category_id: categoryId,
-          amount,
-          user_id: currentUser.id,
+          amount, // Will be mapped to 'budgeted' by budgetService
         });
       }
       // Refresh budgets for the current month
@@ -107,8 +106,7 @@ export default function BudgetPage() {
       await Budget.create({
         month: monthString,
         category_id: selectedCategory,
-        amount: Number(newBudgetAmount),
-        user_id: currentUser.id,
+        amount: Number(newBudgetAmount), // Will be mapped to 'budgeted' by budgetService
       });
 
       // Refresh budgets for the current month

--- a/src/services/budgetService.js
+++ b/src/services/budgetService.js
@@ -120,12 +120,16 @@ class BudgetService {
    * @private
    */
   _mapBudgetToAPI(budget) {
-    return {
+    const payload = {
       category_id: budget.categoryId || budget.category_id,
-      amount: budget.amount,
+      budgeted: budget.budgeted || budget.amount, // Backend expects 'budgeted' not 'amount'
       month: budget.month,
-      year: budget.year,
     };
+
+    // Don't send user_id - backend gets it from JWT token
+    // Don't send year - backend only uses month in YYYY-MM format
+
+    return payload;
   }
 }
 


### PR DESCRIPTION
The backend budget validation schema expects the field name 'budgeted' but the frontend was sending 'amount', causing validation to fail.

Problem:
- Backend budgetSchema requires: month, category_id, budgeted
- Frontend was sending: month, category_id, amount, user_id, year
- This caused "Validation failed" error with 2 validation errors

Solution:
- Updated budgetService._mapBudgetToAPI to:
  * Map 'amount' to 'budgeted' field name
  * Remove user_id (backend gets it from JWT)
  * Remove year (backend only uses month in YYYY-MM format)
- Updated Budget.jsx to remove user_id from create calls
- Added comments explaining the field mapping

This fixes budget creation and updates in the Budget page.