### PR TITLE
Fix budget amount field mapping from backend 'budgeted' to frontend '…

### DIFF
--- a/src/services/budgetService.js
+++ b/src/services/budgetService.js
@@ -102,7 +102,8 @@ class BudgetService {
     return {
       id: apiBudget.id,
       categoryId: apiBudget.category_id,
-      amount: apiBudget.amount,
+      category_id: apiBudget.category_id, // Keep snake_case for compatibility
+      amount: apiBudget.budgeted || apiBudget.amount, // Backend uses 'budgeted' field
       month: apiBudget.month,
       year: apiBudget.year,
       spent: apiBudget.spent,


### PR DESCRIPTION
…amount'

The backend returns budget amounts in a field called 'budgeted', but the frontend _mapBudgetFromAPI was looking for 'amount', causing budgets to show as 0 or undefined after creation.

Changes:
- Changed apiBudget.amount to apiBudget.budgeted || apiBudget.amount
- Added category_id field for snake_case compatibility
- Added comment explaining backend uses 'budgeted' field

This fixes the issue where created budgets weren't showing up in the Budget page list after creation.