### PR TITLE
Fix Reports page category/subcategory display and remove Dashboard ac…

### DIFF
--- a/src/components/reports/CustomReportBuilder.jsx
+++ b/src/components/reports/CustomReportBuilder.jsx
@@ -39,10 +39,15 @@ export default function CustomReportBuilder({ data, accounts, categories, onExpo
         return transaction.payee || '-';
       case 'category':
         const category = categories.find(c => c.id === transaction.category_id);
-        return category?.name || 'Uncategorized';
+        // If category has a parent, show parent; otherwise show category itself
+        const parentCategory = category?.parent_id ? categories.find(c => c.id === category.parent_id) : null;
+        const displayCategory = parentCategory || category;
+        return displayCategory?.name || 'Uncategorized';
       case 'subcategory':
-        const subcategory = categories.find(c => c.id === transaction.subcategory_id);
-        return subcategory?.name || '-';
+        const cat = categories.find(c => c.id === transaction.category_id);
+        // If category has a parent, it IS the subcategory
+        const displaySubcategory = cat?.parent_id ? cat : null;
+        return displaySubcategory?.name || '-';
       case 'amount':
         return formatCurrency(transaction.amount_eur || 0, 'EUR');
       case 'account':

--- a/src/components/reports/ReportDisplay.jsx
+++ b/src/components/reports/ReportDisplay.jsx
@@ -106,14 +106,18 @@ export default function ReportDisplay({ data, categories, isLoading }) {
                     <TableBody>
                         {data.map(t => {
                             const category = categories.find(c => c.id === t.category_id);
-                            const subcategory = categories.find(c => c.id === t.subcategory_id);
+                            // If category has a parent, it's a subcategory
+                            const parentCategory = category?.parent_id ? categories.find(c => c.id === category.parent_id) : null;
+                            const displayCategory = parentCategory || category;
+                            const displaySubcategory = parentCategory ? category : null;
+
                             const color = t.type === 'income' ? 'text-emerald-600' : 'text-red-600';
                             return (
                                 <TableRow key={t.id}>
                                     <TableCell>{new Date(t.date).toLocaleDateString()}</TableCell>
                                     <TableCell>{t.payee}</TableCell>
-                                    <TableCell>{category?.name || 'Uncategorized'}</TableCell>
-                                    <TableCell className="text-slate-500 text-sm">{subcategory?.name || '-'}</TableCell>
+                                    <TableCell>{displayCategory?.name || 'Uncategorized'}</TableCell>
+                                    <TableCell className="text-slate-500 text-sm">{displaySubcategory?.name || '-'}</TableCell>
                                     <TableCell className={`text-right font-medium currency ${color}`}>
                                         {t.type === 'income' ? '+' : '-'} {formatCurrency(t.amount_eur, 'EUR')}
                                     </TableCell>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -13,7 +13,6 @@ import {
   TrendingDown,
   Wallet,
   PiggyBank,
-  DollarSign,
   Calendar,
   ArrowRight
 } from "lucide-react";
@@ -619,47 +618,6 @@ export default function Dashboard() {
           isLoading={isLoading}
         />
       </div>
-
-      <Card className="border-0 shadow-sm bg-white">
-        <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-gray-900 font-semibold">
-            <DollarSign className="w-5 h-5 text-gray-600" />
-            Account Balances
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {accounts.map((account) => {
-              const isDebtAccount = account.type === 'loan' || account.type === 'credit_card';
-              const balanceShouldBeRed = isDebtAccount || (account.balance || 0) < 0;
-
-              return (
-                <div key={account.id} className="p-6 rounded-xl border border-gray-100 bg-gray-50/50 hover:bg-gray-50 transition-colors">
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <h3 className="font-semibold text-gray-900 mb-1">{account.name}</h3>
-                      <p className="text-sm text-gray-500 capitalize font-medium">{account.type.replace('_', ' ')}</p>
-                    </div>
-                    <span className="text-xs font-semibold text-gray-600 bg-white px-2 py-1 rounded-md border border-gray-200">
-                      {account.currency}
-                    </span>
-                  </div>
-                  <div className="mt-4">
-                    <p className={`text-2xl currency-large ${
-                      balanceShouldBeRed ? 'text-red-600' : 'text-emerald-600'
-                    }`}>
-                      {formatCurrency(account.balance || 0, account.currency, true, false)}
-                    </p>
-                    <p className="text-sm text-muted-foreground mt-1 currency">
-                      ≈ €{formatNumber(account.balance_eur || 0, true)}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </CardContent>
-      </Card>
     </div>
   );
 }


### PR DESCRIPTION
…count section

1. Fixed Reports page (Overview & Report Builder tabs):
   - Category column now shows parent category
   - Subcategory column shows actual subcategory
   - Previous issue: subcategories were showing in category column
   - Logic: If category has parent_id, show parent in category column and category itself in subcategory column

Changes in ReportDisplay.jsx:
   - Calculate parentCategory based on category.parent_id
   - Set displayCategory = parentCategory || category
   - Set displaySubcategory = parentCategory ? category : null

Changes in CustomReportBuilder.jsx:
   - Updated getCellValue for 'category' case to check parent_id
   - Updated getCellValue for 'subcategory' case to show category if it has parent

2. Removed Account Balances section from Dashboard:
   - Removed entire Card showing account balances
   - Removed unused DollarSign icon import
   - Rationale: Dedicated Accounts page already shows this info
   - Lines removed: 623-662 (Account Balances Card)

This improves clarity in Reports and reduces duplication in Dashboard.