### PR TITLE
Fix Goals form error when creating goal without linked account

### DIFF
--- a/src/components/goals/GoalForm.jsx
+++ b/src/components/goals/GoalForm.jsx
@@ -46,6 +46,12 @@ export default function GoalForm({ goal, accounts, onSubmit, onCancel }) {
       target_amount: Number(formData.target_amount),
       current_amount: Number(formData.current_amount),
     };
+
+    // Remove linked_account_id if it's empty string (None selected)
+    if (!dataToSubmit.linked_account_id || dataToSubmit.linked_account_id === '') {
+      delete dataToSubmit.linked_account_id;
+    }
+
     onSubmit(dataToSubmit);
   };
 


### PR DESCRIPTION
The form was submitting linked_account_id as empty string when 'None' was selected, causing a validation error on the backend.

Fix: Remove linked_account_id from the payload if it's empty string or falsy. This allows goals to be created without a linked account.

This resolves the 'Something went wrong' error when adding goals.