### PR TITLE
Fix Goals form SelectItem empty string value error

### DIFF
--- a/src/components/goals/GoalForm.jsx
+++ b/src/components/goals/GoalForm.jsx
@@ -90,10 +90,9 @@ export default function GoalForm({ goal, accounts, onSubmit, onCancel }) {
         <Label htmlFor="linked_account_id">Link to an Account (Optional)</Label>
         <Select value={formData.linked_account_id} onValueChange={(value) => handleChange('linked_account_id', value)}>
           <SelectTrigger>
-            <SelectValue placeholder="Select an account" />
+            <SelectValue placeholder="None (optional)" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">None</SelectItem>
             {accounts.filter(a => a.type !== 'loan' && a.type !== 'credit_card').map(account => (
               <SelectItem key={account.id} value={account.id}>
                 {account.name} ({account.type})


### PR DESCRIPTION
Radix UI Select component doesn't allow SelectItem with value="" (empty string). Error: "A <Select.Item /> must have a value prop that is not an empty string."

Fix:
- Removed <SelectItem value="">None</SelectItem> line
- Changed placeholder to "None (optional)" to indicate no selection
- Users see placeholder when no account is linked
- Form still converts empty linked_account_id to null in handleSubmit

This resolves the React error and allows Goals page to load and function.