### PR TITLE
Revert CategorySpendingChart to match design spec from val branch

### DIFF
--- a/src/components/dashboard/CategorySpendingChart.jsx
+++ b/src/components/dashboard/CategorySpendingChart.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, Tooltip, Cell } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
 import { FolderTree } from "lucide-react";
 
 // Design System Colors
-const COLORS = ['#2563EB', '#6366F1', '#8B5CF6', '#10b981', '#f59e0b', '#ef4444', '#06b6d4', '#84cc16', '#ec4899', '#14b8a6'];
+const COLORS = ['#2563EB', '#6366F1', '#8B5CF6', '#10b981', '#f59e0b', '#ef4444', '#06b6d4', '#84cc16'];
 
 export default function CategorySpendingChart({ transactions, categories, isLoading }) {
   const expenseTransactions = transactions.filter(t => t.type === 'expense');
@@ -20,8 +20,7 @@ export default function CategorySpendingChart({ transactions, categories, isLoad
   const data = Object.entries(categorySpending)
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value)
-    .slice(0, 10) // Top 10 categories
-    .reverse(); // Reverse so largest is at bottom
+    .slice(0, 8);
 
   const CustomTooltip = ({ active, payload }) => {
     if (active && payload && payload.length) {
@@ -48,42 +47,45 @@ export default function CategorySpendingChart({ transactions, categories, isLoad
       </CardHeader>
       <CardContent>
         {!isLoading && data.length > 0 ? (
-          <ResponsiveContainer width="100%" height={400}>
-            <BarChart
-              data={data}
-              layout="vertical"
-              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-              <XAxis
-                type="number"
-                tickFormatter={(value) => `€${value.toFixed(0)}`}
-                stroke="#6b7280"
-                style={{ fontSize: '12px' }}
-              />
-              <YAxis
-                type="category"
-                dataKey="name"
-                width={120}
-                stroke="#6b7280"
-                style={{ fontSize: '12px' }}
-              />
-              <Tooltip content={<CustomTooltip />} />
-              <Bar
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <defs>
+                {data.map((entry, index) => (
+                  <linearGradient key={`gradient-${index}`} id={`categoryGradient${index}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={COLORS[index % COLORS.length]} stopOpacity={0.9} />
+                    <stop offset="100%" stopColor={COLORS[index % COLORS.length]} stopOpacity={0.7} />
+                  </linearGradient>
+                ))}
+              </defs>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                innerRadius={80}
+                outerRadius={110}
+                paddingAngle={2}
                 dataKey="value"
-                radius={[0, 4, 4, 0]}
+                strokeWidth={0}
                 animationBegin={0}
                 animationDuration={400}
                 animationEasing="ease-in-out"
               >
                 {data.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                  <Cell key={`cell-${index}`} fill={`url(#categoryGradient${index})`} />
                 ))}
-              </Bar>
-            </BarChart>
+              </Pie>
+              <Tooltip content={<CustomTooltip />} />
+              <Legend
+                wrapperStyle={{
+                  fontSize: '12px',
+                  fontFamily: 'Inter, sans-serif',
+                  paddingTop: '16px'
+                }}
+              />
+            </PieChart>
           </ResponsiveContainer>
         ) : (
-          <div className="flex items-center justify-center h-[400px] text-muted-foreground">
+          <div className="flex items-center justify-center h-[300px] text-muted-foreground">
             <div className="text-center">
               <FolderTree className="w-12 h-12 mx-auto mb-4 opacity-30" />
               <p className="font-medium">No expense data for this month</p>


### PR DESCRIPTION
COMPLIANCE CHECK RESULTS:
❌ Current implementation (horizontal bar chart) does NOT match design spec ✅ Reverted to design spec version (donut chart with gradients)

DESIGN SPEC REQUIREMENTS (from val branch commit 694bc92): CategorySpendingChart should be a DONUT CHART with:
- Dynamic gradient generation for each category
- Design system colors: #2563EB, #6366F1, #8B5CF6, #10b981, #f59e0b, #ef4444
- innerRadius: 80, outerRadius: 110 (ring thickness)
- paddingAngle: 2px between segments
- 400ms animation with ease-in-out easing
- Gradient fills with opacity variation (0.9 → 0.7)
- Top 8 categories displayed
- Legend with Inter font (12px)

WHAT WAS CHANGED:
- Reverted from BarChart (horizontal) back to PieChart (donut)
- Restored gradient fills for each segment
- Removed CartesianGrid, XAxis, YAxis (bar chart elements)
- Restored Legend component
- Changed height from 400px to 300px (design spec)
- Changed top 10 → top 8 categories (design spec)
- Removed "largest at bottom" sorting logic (not applicable to donut)

DESIGN PHILOSOPHY:
Per Finance_Tracker_Design_System.md:
- "Use soft gradient fills for charts"
- "Bars and lines follow primary color palette"
- "Animation: smooth ease-in-out (300–400ms)"

This change restores visual consistency with the design system.