### PR TITLE
Fix narrow bar chart display by adding proper X-axis configuration

### DIFF
--- a/src/components/dashboard/CategorySpendingChart.jsx
+++ b/src/components/dashboard/CategorySpendingChart.jsx
@@ -75,7 +75,11 @@ export default function CategorySpendingChart({ transactions, categories, isLoad
                 })}
               </defs>
               <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-              <XAxis type="number" />
+              <XAxis
+                type="number"
+                domain={[0, 'dataMax']}
+                tickFormatter={(value) => `€${value.toFixed(0)}`}
+              />
               <YAxis
                 type="category"
                 dataKey="name"
@@ -83,7 +87,11 @@ export default function CategorySpendingChart({ transactions, categories, isLoad
                 tick={{ fontSize: 12 }}
               />
               <Tooltip content={<CustomTooltip />} />
-              <Bar dataKey="value" radius={[0, 8, 8, 0]}>
+              <Bar
+                dataKey="value"
+                radius={[0, 8, 8, 0]}
+                maxBarSize={40}
+              >
                 {data.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={`url(#dashboardBarGradient${index})`} />
                 ))}

--- a/src/components/insights/SpendingInsights.jsx
+++ b/src/components/insights/SpendingInsights.jsx
@@ -175,7 +175,11 @@ export default function SpendingInsights({ transactions, categories, accounts, i
                     })}
                   </defs>
                   <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-                  <XAxis type="number" />
+                  <XAxis
+                    type="number"
+                    domain={[0, 'dataMax']}
+                    tickFormatter={(value) => `€${value.toFixed(0)}`}
+                  />
                   <YAxis
                     type="category"
                     dataKey="name"
@@ -191,7 +195,11 @@ export default function SpendingInsights({ transactions, categories, accounts, i
                       boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
                     }}
                   />
-                  <Bar dataKey="amount" radius={[0, 8, 8, 0]}>
+                  <Bar
+                    dataKey="amount"
+                    radius={[0, 8, 8, 0]}
+                    maxBarSize={40}
+                  >
                     {insights.topCategories.map((entry, index) => (
                       <Cell key={`cell-${index}`} fill={`url(#barGradient${index})`} />
                     ))}


### PR DESCRIPTION
- Add XAxis domain [0, 'dataMax'] to ensure bars start from 0
- Add tickFormatter to display currency values on X-axis (e.g., €500)
- Add maxBarSize={40} to control bar thickness and prevent overly narrow bars
- Applied to both Dashboard CategorySpendingChart and Insights SpendingInsights

This fixes the issue where bars appeared very narrow due to uncontrolled axis scaling.