### PR TITLE
Improve bar chart sizing and add net worth debugging

### DIFF
--- a/src/components/dashboard/CategorySpendingChart.jsx
+++ b/src/components/dashboard/CategorySpendingChart.jsx
@@ -77,20 +77,21 @@ export default function CategorySpendingChart({ transactions, categories, isLoad
               <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
               <XAxis
                 type="number"
-                domain={[0, 'dataMax']}
+                domain={[0, 'auto']}
                 tickFormatter={(value) => `€${value.toFixed(0)}`}
+                padding={{ right: 20 }}
               />
               <YAxis
                 type="category"
                 dataKey="name"
-                width={110}
+                width={120}
                 tick={{ fontSize: 12 }}
               />
               <Tooltip content={<CustomTooltip />} />
               <Bar
                 dataKey="value"
                 radius={[0, 8, 8, 0]}
-                maxBarSize={40}
+                barSize={50}
               >
                 {data.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={`url(#dashboardBarGradient${index})`} />

--- a/src/components/insights/HistoricalData.jsx
+++ b/src/components/insights/HistoricalData.jsx
@@ -69,6 +69,13 @@ export default function HistoricalData({ transactions, accounts, categories, isL
     // Estimate starting net worth = current net worth - total savings in the period
     const startingNetWorth = currentNetWorth - totalSavingsInPeriod;
 
+    console.log('HistoricalData Debug:', {
+      currentNetWorth,
+      totalSavingsInPeriod,
+      startingNetWorth,
+      monthCount: monthlyData.length
+    });
+
     // Now build the final data with cumulative net worth
     let cumulativeNetWorth = startingNetWorth;
 

--- a/src/components/insights/SpendingInsights.jsx
+++ b/src/components/insights/SpendingInsights.jsx
@@ -177,13 +177,14 @@ export default function SpendingInsights({ transactions, categories, accounts, i
                   <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
                   <XAxis
                     type="number"
-                    domain={[0, 'dataMax']}
+                    domain={[0, 'auto']}
                     tickFormatter={(value) => `€${value.toFixed(0)}`}
+                    padding={{ right: 20 }}
                   />
                   <YAxis
                     type="category"
                     dataKey="name"
-                    width={110}
+                    width={120}
                     tick={{ fontSize: 12 }}
                   />
                   <Tooltip
@@ -198,7 +199,7 @@ export default function SpendingInsights({ transactions, categories, accounts, i
                   <Bar
                     dataKey="amount"
                     radius={[0, 8, 8, 0]}
-                    maxBarSize={40}
+                    barSize={50}
                   >
                     {insights.topCategories.map((entry, index) => (
                       <Cell key={`cell-${index}`} fill={`url(#barGradient${index})`} />


### PR DESCRIPTION
Bar Chart Improvements:
- Changed XAxis domain from 'dataMax' to 'auto' for better auto-scaling
- Increased barSize from maxBarSize=40 to fixed barSize=50 for thicker bars
- Added XAxis padding (right: 20) for better spacing
- Increased YAxis width from 110 to 120 for longer category names

Net Worth Debugging:
- Added console.log to debug historical net worth calculation
- Logs currentNetWorth, totalSavingsInPeriod, startingNetWorth, monthCount

This should make bars more visible and help diagnose net worth calculation issues.