### PR TITLE
Add premium protection to all premium feature pages

### DIFF
--- a/src/pages/DebtPayoff.jsx
+++ b/src/pages/DebtPayoff.jsx
@@ -14,8 +14,10 @@ import {
 import DebtPayoffPlanCard from "../components/debt/DebtPayoffPlanCard";
 import DebtPayoffPlanForm from "../components/debt/DebtPayoffPlanForm";
 import DebtOverview from "../components/debt/DebtOverview";
+import PremiumPageWrapper from "../components/PremiumPageWrapper";
+import { FEATURES } from "../utils/featureAccess";
 
-export default function DebtPayoffPage() {
+function DebtPayoffPageContent() {
   const [currentUser, setCurrentUser] = useState(null);
   const [debtAccounts, setDebtAccounts] = useState([]);
   const [payoffPlans, setPayoffPlans] = useState([]);
@@ -199,5 +201,13 @@ export default function DebtPayoffPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function DebtPayoffPage() {
+  return (
+    <PremiumPageWrapper feature={FEATURES.DEBT_PAYOFF} featureName="Debt Payoff Planner">
+      <DebtPayoffPageContent />
+    </PremiumPageWrapper>
   );
 }

--- a/src/pages/Forecast.jsx
+++ b/src/pages/Forecast.jsx
@@ -7,8 +7,10 @@ import { fetchExchangeRates, convertCurrency } from "../utils/exchangeRateApi";
 import ForecastControls from "../components/forecast/ForecastControls";
 import ForecastChart from "../components/forecast/ForecastChart";
 import ForecastSummary from "../components/forecast/ForecastSummary";
+import PremiumPageWrapper from "../components/PremiumPageWrapper";
+import { FEATURES } from "../utils/featureAccess";
 
-export default function ForecastPage() {
+function ForecastPageContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [currentNetWorth, setCurrentNetWorth] = useState(0);
   const [currentUser, setCurrentUser] = useState(null); // Added currentUser state
@@ -163,5 +165,13 @@ export default function ForecastPage() {
 
       <ForecastChart data={projectionData} isLoading={isLoading} />
     </div>
+  );
+}
+
+export default function ForecastPage() {
+  return (
+    <PremiumPageWrapper feature={FEATURES.FORECAST} featureName="Financial Forecast">
+      <ForecastPageContent />
+    </PremiumPageWrapper>
   );
 }

--- a/src/pages/Insights.jsx
+++ b/src/pages/Insights.jsx
@@ -9,8 +9,10 @@ import SpendingInsights from "../components/insights/SpendingInsights";
 import AIInsights from "../components/insights/AIInsights";
 import PeriodComparison from "../components/insights/PeriodComparison";
 import HistoricalData from "../components/insights/HistoricalData";
+import PremiumPageWrapper from "../components/PremiumPageWrapper";
+import { FEATURES } from "../utils/featureAccess";
 
-export default function InsightsPage() {
+function InsightsPageContent() {
   const { categories: sharedCategories } = useApp();
   const [currentUser, setCurrentUser] = useState(null);
   const [transactions, setTransactions] = useState([]);
@@ -111,5 +113,13 @@ export default function InsightsPage() {
         </TabsContent>
       </Tabs>
     </div>
+  );
+}
+
+export default function InsightsPage() {
+  return (
+    <PremiumPageWrapper feature={FEATURES.AI_INSIGHTS} featureName="AI-Powered Insights">
+      <InsightsPageContent />
+    </PremiumPageWrapper>
   );
 }

--- a/src/pages/Reconciliation.jsx
+++ b/src/pages/Reconciliation.jsx
@@ -11,6 +11,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ClipboardCheck, Wallet, Milestone, Scale, Landmark, PiggyBank, CreditCard, Briefcase } from "lucide-react";
 import { format, startOfMonth } from "date-fns";
+import PremiumPageWrapper from "../components/PremiumPageWrapper";
+import { FEATURES } from "../utils/featureAccess";
 
 const accountIcons = {
   checking: Landmark,
@@ -21,7 +23,7 @@ const accountIcons = {
   loan: CreditCard
 };
 
-export default function ReconciliationPage() {
+function ReconciliationPageContent() {
     const { user: currentUser } = useCurrentUser(); // Get user from AppContext
     const [accounts, setAccounts] = useState([]);
     const [selectedAccountId, setSelectedAccountId] = useState("");
@@ -296,5 +298,13 @@ export default function ReconciliationPage() {
                 </div>
             )}
         </div>
+    );
+}
+
+export default function ReconciliationPage() {
+    return (
+        <PremiumPageWrapper feature={FEATURES.RECONCILIATION} featureName="Account Reconciliation">
+            <ReconciliationPageContent />
+        </PremiumPageWrapper>
     );
 }

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -7,10 +7,12 @@ import ReportFilters from '../components/reports/ReportFilters';
 import ReportDisplay from '../components/reports/ReportDisplay';
 import CustomReportBuilder from '../components/reports/CustomReportBuilder';
 import { useApp } from '../context/AppContext';
+import PremiumPageWrapper from '../components/PremiumPageWrapper';
+import { FEATURES } from '../utils/featureAccess';
 
 import { startOfMonth, endOfMonth } from 'date-fns';
 
-export default function ReportsPage() {
+function ReportsPageContent() {
   const { categories } = useApp();
   const [currentUser, setCurrentUser] = useState(null);
   const [accounts, setAccounts] = useState([]);
@@ -111,5 +113,13 @@ export default function ReportsPage() {
         </TabsContent>
       </Tabs>
     </div>
+  );
+}
+
+export default function ReportsPage() {
+  return (
+    <PremiumPageWrapper feature={FEATURES.REPORTS} featureName="Advanced Reports">
+      <ReportsPageContent />
+    </PremiumPageWrapper>
   );
 }


### PR DESCRIPTION
Wrapped the following pages with PremiumPageWrapper:
- Reports page (Advanced Reports feature)
- DebtPayoff page (Debt Payoff Planner feature)
- Reconciliation page (Account Reconciliation feature)
- Insights page (AI-Powered Insights feature)
- Forecast page (Financial Forecast feature)

Basic users will now see upgrade prompts when trying to access these features.